### PR TITLE
Prototype Behavior Interface

### DIFF
--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
@@ -3,10 +3,13 @@ from pynwb.file import NWBFile
 from pydantic import FilePath
 import numpy as np
 from h5py import File
+from hdmf.common.table import DynamicTableRegion
 from pynwb.behavior import BehavioralTimeSeries, TimeSeries
+from ndx_events import EventTypesTable, EventsTable, Task, TimestampVectorData
 
 from neuroconv.basedatainterface import BaseDataInterface
 from neuroconv.utils import DeepDict
+from neuroconv.tools import nwb_helpers
 
 
 class Schneider2024BehaviorInterface(BaseDataInterface):
@@ -57,4 +60,52 @@ class Schneider2024BehaviorInterface(BaseDataInterface):
             time_series=[encoder_time_series, lick_time_series],
             name="behavioral_time_series",
         )
-        nwbfile.add_acquisition(behavioral_time_series)
+        behavior_module = nwb_helpers.get_module(
+            nwbfile=nwbfile,
+            name="behavior",
+            description="Behavioral data from the experiment.",
+        )
+        behavior_module.add(behavioral_time_series)
+
+        event_types_table = EventTypesTable(name="event_types", description="Metadata about event types.")
+        event_types_table.add_row(
+            event_name="target", event_type_description="Time at which the target zone is entered during a press."
+        )
+        event_types_table.add_row(
+            event_name="target_out", event_type_description="Time at which the target zone is overshot during a press."
+        )
+        event_types_table.add_row(
+            event_name="tone_in", event_type_description="Time at which target entry tone is played."
+        )
+        event_types_table.add_row(
+            event_name="tone_out", event_type_description="Time at which target exit tone is played."
+        )
+        event_types_table.add_row(
+            event_name="tuning_tone",
+            event_type_description="Times at which tuning tones are played to an animal after a behavioral experiment during ephys recording sessions.",
+        )
+        event_types_table.add_row(
+            event_name="valve",
+            event_type_description="Times at which solenoid valve opens to deliver water after a correct trial.",
+        )
+
+        events_table = EventsTable(
+            name="events_table",
+            description="Metadata about events.",
+            target_tables={"event_type": event_types_table},
+        )
+        nested_event_times = [
+            target_times,
+            target_out_times,
+            tone_in_times,
+            tone_out_times,
+            tuning_tone_times,
+            valve_times,
+        ]
+        for i, event_times in enumerate(nested_event_times):
+            for event_time in event_times:
+                events_table.add_row(timestamp=event_time, event_type=i)
+        behavior_module.add(events_table)
+
+        task = Task(event_types=event_types_table)
+        nwbfile.add_lab_meta_data(task)

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
@@ -91,19 +91,25 @@ class Schneider2024BehaviorInterface(BaseDataInterface):
             description="Metadata about events.",
             target_tables={"event_type": event_types_table},
         )
-        events_table.add_column(name="value", description="Value of the event.")
         for event_dict in metadata["Behavior"]["Events"]:
             event_times = name_to_times[event_dict["name"]]
             event_type = event_type_name_to_row[event_dict["name"]]
             for event_time in event_times:
-                events_table.add_row(timestamp=event_time, event_type=event_type, value="")
+                events_table.add_row(timestamp=event_time, event_type=event_type)
+        valued_events_table = EventsTable(
+            name="valued_events_table",
+            description="Metadata about valued events.",
+            target_tables={"event_type": event_types_table},
+        )
+        valued_events_table.add_column(name="value", description="Value of the event.")
         for event_dict in metadata["Behavior"]["ValuedEvents"]:
             event_times = name_to_times[event_dict["name"]]
             event_values = name_to_values[event_dict["name"]]
             event_type = event_type_name_to_row[event_dict["name"]]
             for event_time, event_value in zip(event_times, event_values):
-                events_table.add_row(timestamp=event_time, event_type=event_type, value=str(event_value))
+                valued_events_table.add_row(timestamp=event_time, event_type=event_type, value=event_value)
         behavior_module.add(events_table)
+        behavior_module.add(valued_events_table)
 
         task = Task(event_types=event_types_table)
         nwbfile.add_lab_meta_data(task)

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_behaviorinterface.py
@@ -1,25 +1,60 @@
 """Primary class for converting experiment-specific behavior."""
 from pynwb.file import NWBFile
+from pydantic import FilePath
+import numpy as np
+from h5py import File
+from pynwb.behavior import BehavioralTimeSeries, TimeSeries
 
 from neuroconv.basedatainterface import BaseDataInterface
 from neuroconv.utils import DeepDict
+
 
 class Schneider2024BehaviorInterface(BaseDataInterface):
     """Behavior interface for schneider_2024 conversion"""
 
     keywords = ["behavior"]
-    
-    def __init__(self):
-        # This should load the data lazily and prepare variables you need
-        pass
+
+    def __init__(self, file_path: FilePath):
+        super().__init__(file_path=file_path)
 
     def get_metadata(self) -> DeepDict:
         # Automatically retrieve as much metadata as possible from the source files available
-        metadata = super().get_metadata()   
+        metadata = super().get_metadata()
 
         return metadata
 
     def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
-        # All the custom code to add the data the nwbfile
+        file_path = self.source_data["file_path"]
+        with File(file_path, "r") as file:
+            encoder_timestamps = np.array(file["continuous"]["encoder"]["time"]).squeeze()
+            encoder_values = np.array(file["continuous"]["encoder"]["value"]).squeeze()
+            lick_timestamps = np.array(file["continuous"]["lick"]["time"]).squeeze()
+            lick_values = np.array(file["continuous"]["lick"]["value"]).squeeze()
 
-        raise NotImplementedError()
+            target_times = np.array(file["events"]["target"]["time"]).squeeze()
+            target_out_times = np.array(file["events"]["targetOUT"]["time"]).squeeze()
+            tone_in_times = np.array(file["events"]["toneIN"]["time"]).squeeze()
+            tone_out_times = np.array(file["events"]["toneOUT"]["time"]).squeeze()
+            tuning_tone_times = np.array(file["events"]["tuningTones"]["time"]).squeeze()
+            tuning_tone_values = np.array(file["events"]["tuningTones"]["value"]).squeeze()
+            valve_times = np.array(file["events"]["valve"]["time"]).squeeze()
+
+        encoder_time_series = TimeSeries(
+            name="encoder",
+            timestamps=encoder_timestamps,
+            data=encoder_values,
+            unit="a.u.",
+            description="Sampled values for entire duration of experiment for lever pressing/treadmill behavior read from a quadrature encoder.",
+        )
+        lick_time_series = TimeSeries(
+            name="lick",
+            timestamps=lick_timestamps,
+            data=lick_values,
+            unit="a.u.",
+            description="Samples values for entire duration of experiment for voltage signal readout from an infrared/capacitive) lickometer sensor.",
+        )
+        behavioral_time_series = BehavioralTimeSeries(
+            time_series=[encoder_time_series, lick_time_series],
+            name="behavioral_time_series",
+        )
+        nwbfile.add_acquisition(behavioral_time_series)

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_convert_session.py
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_convert_session.py
@@ -17,6 +17,7 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
     output_dir_path = Path(output_dir_path)
     recording_folder_path = data_dir_path / "Raw Ephys" / "m69_2023-10-31_17-24-15_Day1_A1"
     sorting_folder_path = data_dir_path / "Processed Ephys" / "m69_2023-10-31_17-24-15_Day1_A1"
+    behavior_file_path = data_dir_path / "Behavior" / "m69_231031" / "raw_m69_231031_001.mat"
     if stub_test:
         output_dir_path = output_dir_path / "nwb_stub"
         recording_folder_path = recording_folder_path.with_name(recording_folder_path.name + "_stubbed")
@@ -37,9 +38,9 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
     source_data.update(dict(Sorting=dict(folder_path=sorting_folder_path)))
     conversion_options.update(dict(Sorting=dict()))
 
-    # # Add Behavior
-    # source_data.update(dict(Behavior=dict()))
-    # conversion_options.update(dict(Behavior=dict()))
+    # Add Behavior
+    source_data.update(dict(Behavior=dict(file_path=behavior_file_path)))
+    conversion_options.update(dict(Behavior=dict()))
 
     converter = Schneider2024NWBConverter(source_data=source_data)
 

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_metadata.yaml
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_metadata.yaml
@@ -1,5 +1,5 @@
 NWBFile:
-  keywords: 
+  keywords:
     - auditory cortex
     - predictive coding
     - optogenetics
@@ -53,3 +53,23 @@ Ecephys:
     #   description: The channel label of the best channel, as defined by the user.
     # - name: sh
     #   description: The shank label of the best channel.
+Behavior:
+  TimeSeries:
+    - name: encoder
+      description: Sampled values for entire duration of experiment for lever pressing/treadmill behavior read from a quadrature encoder.
+    - name: lick
+      description: Samples values for entire duration of experiment for voltage signal readout from an infrared/capacitive) lickometer sensor.
+  Events:
+    - name: target
+      description: Time at which the target zone is entered during a press.
+    - name: targetOUT
+      description: Time at which the target zone is overshot during a press.
+    - name: toneIN
+      description: Time at which target entry tone is played.
+    - name: toneOUT
+      description: Time at which target exit tone is played.
+    - name: valve
+      description: Times at which solenoid valve opens to deliver water after a correct trial.
+  ValuedEvents:
+    - name: tuningTones
+      description: Times at which tuning tones are played to an animal after a behavioral experiment during ephys recording sessions.

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
@@ -11,4 +11,4 @@
 - More detailed position info for recording probe
     - Subfield of auditory cortex: A1? A2? AAF? etc.
     - stereotactic coordinates of the whole probe
--
+- Detailed description of the behavioral paradigm

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
@@ -12,3 +12,4 @@
     - Subfield of auditory cortex: A1? A2? AAF? etc.
     - stereotactic coordinates of the whole probe
 - Detailed description of the behavioral paradigm
+- Description of lickometer and lever/treadmill quadrature encoder.

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_notes.md
@@ -1,9 +1,14 @@
 # Notes concerning the schneider_2024 conversion
 
+## Behavior
+- opto events is just [0, 1] like empty variables (lick events), and opto_time in 'push' is all NaNs.  Where is the actual opto stim times recorded?
+- TuningTones has a values field with integers, what does this correspond to?
+- 'push' is basically some kind of trials table, but need descriptions for variables ex. ITI_respect?
+
 ## Data Requests
 - Mice sexes
 - Remaining data for Grant's project
 - More detailed position info for recording probe
     - Subfield of auditory cortex: A1? A2? AAF? etc.
     - stereotactic coordinates of the whole probe
-- 
+-

--- a/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_nwbconverter.py
+++ b/src/schneider_lab_to_nwb/schneider_2024/schneider_2024_nwbconverter.py
@@ -14,4 +14,5 @@ class Schneider2024NWBConverter(NWBConverter):
     data_interface_classes = dict(
         Recording=OpenEphysRecordingInterface,
         Sorting=PhySortingInterface,
+        Behavior=Schneider2024BehaviorInterface,
     )


### PR DESCRIPTION
Converts all well-described behavioral data from .mat file. Makes note of fields that need more info from Schneider lab (ex. 'push' trials table)