### PR TITLE
fixed trials table temporal alignment

### DIFF
--- a/src/schneider_lab_to_nwb/zempolich_2024/zempolich_2024_behaviorinterface.py
+++ b/src/schneider_lab_to_nwb/zempolich_2024/zempolich_2024_behaviorinterface.py
@@ -154,6 +154,8 @@ class Zempolich2024BehaviorInterface(BaseDataInterface):
             if dtype == "bool":
                 trial_array[np.isnan(trial_array)] = False
             trial_array = np.asarray(trial_array, dtype=dtype)  # Can't cast to dtype right away bc bool(nan) = True
+            if normalize_timestamps and name in ["time_reward_s", "opto_time", "opto_time_end"]:
+                trial_array = trial_array - starting_timestamp
             name_to_trial_array[name] = trial_array[~trial_is_nan]
 
         # Add Data to NWBFile


### PR DESCRIPTION
Found a bug in the temporal alignment: In opto sessions, the time-based entries of the trials table were not being normalized to the start_time.