### PR TITLE
pinned python to 3.12

### DIFF
--- a/make_env.yml
+++ b/make_env.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python>=3.9
+- python==3.12
 - pip
 - pip:
   - -e .  # This calls the setup and therefore pyproject.toml dependencies


### PR DESCRIPTION
This should fix an install bug in windows that was caused by python being stuck on 3.13