### PR TITLE
added fix for complex numbers

### DIFF
--- a/src/schneider_lab_to_nwb/zempolich_2024/zempolich_2024_behaviorinterface.py
+++ b/src/schneider_lab_to_nwb/zempolich_2024/zempolich_2024_behaviorinterface.py
@@ -116,6 +116,8 @@ class Zempolich2024BehaviorInterface(BaseDataInterface):
             if normalize_timestamps:
                 timestamps = timestamps - starting_timestamp
             data = np.array(file["continuous"][name]["value"]).squeeze()
+            if data.dtype == np.complex128:
+                data = data.real.astype(np.float64)
             time_series = TimeSeries(
                 name=name,
                 timestamps=timestamps,


### PR DESCRIPTION
Noticed that one of the behavioral variables has complex numbers that are messing with neurosift visualizations -- see [here](https://github.com/flatironinstitute/neurosift/issues/219).

Grant said I can just disregard the imaginary part.